### PR TITLE
FIX Ensure yarn scripts exist before running them

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -190,14 +190,21 @@ runs:
           yarn install --network-concurrency 1
           cd ../../..
         fi
-        yarn run build
-        echo "Running git diff"
-        git diff-files --quiet -w --relative=client
-        git diff --name-status --relative=client
-        echo "Running yarn test"
-        yarn run test
-        echo "Running yarn lint"
-        yarn run lint
+         if [[ $(cat package.json | jq -r '.scripts.build') != 'null' ]]; then
+          echo "Running yarn build"
+          yarn run build
+          echo "Running git diff"
+          git diff-files --quiet -w --relative=client
+          git diff --name-status --relative=client
+        fi
+        if [[ $(cat package.json | jq -r '.scripts.test') != 'null' ]]; then
+          echo "Running yarn test"
+          yarn run test
+        fi
+        if [[ $(cat package.json | jq -r '.scripts.lint') != 'null' ]]; then
+          echo "Running yarn lint"
+          yarn run lint
+        fi
         echo "Passed"
 
     - name: "Run PHP linting"


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Some package.json files do not have yarn scripts build/test/lint defined. If not defined, then skip them.

Example
```
Running yarn test
yarn run v1.22.19
error Command "test" not found.
```
https://github.com/creative-commoners/cwp-starter-theme/runs/7242059614?check_suite_focus=true#step:12:347
