### PR TITLE
FIX Allow different node versions for admin vs module

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -180,16 +180,23 @@ runs:
         export NVM_DIR="$HOME/.nvm"
         # this loads nvm into the current terminal
         [[ -s "$NVM_DIR/nvm.sh" ]] && \. "$NVM_DIR/nvm.sh"
-        nvm install
-        nvm use
-        rm -rf client/dist
-        npm install -g yarn
-        yarn install --network-concurrency 1
+        ADMIN_NPM_VERSION=
         if [[ -d vendor/silverstripe/admin ]]; then
           cd vendor/silverstripe/admin
+          nvm install
+          nvm use
+          ADMIN_NPM_VERSION=$(npm -v)
+          npm install -g yarn
           yarn install --network-concurrency 1
           cd ../../..
         fi
+        nvm install
+        nvm use
+        rm -rf client/dist
+        if [[ $(npm -v) != $ADMIN_NPM_VERSION ]]; then
+          npm install -g yarn;
+        fi
+        yarn install --network-concurrency 1
          if [[ $(cat package.json | jq -r '.scripts.build') != 'null' ]]; then
           echo "Running yarn build"
           yarn run build


### PR DESCRIPTION
Allow the module to have a different version of node than admin

Allows a fix for https://github.com/silverstripe/silverstripe-contentreview/runs/7401209441?check_suite_focus=true
> error silverstripe-contentreview@4.0.0: The engine "node" is incompatible with this module. Expected version "^6.x". Got "10.24.1"

## Parent issue
- https://github.com/silverstripe/gha-ci/issues/37