### PR TITLE
ENH Don't do cow lint in CI

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -245,11 +245,6 @@ runs:
           echo "Running PHPStan"
           vendor/bin/phpstan analyse
         fi
-        # cow validation is also done here due to it being a tiny piece of work not meriting its own step
-        if [[ -f .cow.json ]]; then
-          echo "Running cow schema validate"
-          vendor/bin/cow schema:validate
-        fi
         echo "Passed"
 
     - name: "Run PHP coverage"


### PR DESCRIPTION
This belongs as part of the release process, not in CI. Requires https://github.com/silverstripe/gha-ci/pull/61

Fixes https://github.com/silverstripe/recipe-solr-search/actions/runs/4262437888/jobs/7493366539
cow cannot install with some of the other dependencies.

## Parent issue
- https://github.com/silverstripe/.github/issues/6