### PR TITLE
FIX Change default value of doclinting to false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
     default: false
   doclinting:
     type: boolean
-    default: true
+    default: false
 
 runs:
   using: composite


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/218

Default value should be false, similar to phpunit, endtoend etc having a false default.

This is to prevent behat tests from mistakenly running doclint e.g. https://github.com/silverstripe/silverstripe-contentreview/actions/runs/8553905339/job/23596501036#step:12:269

gha-generate-matrix will correctly create jobs with doclinting true when appropriate e.g. https://github.com/silverstripe/silverstripe-linkfield/actions/runs/8624795350/job/23640385514