### PR TITLE
FIX Fix nvm installation`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -203,6 +203,8 @@ runs:
           echo "Missing .nvmrc"
           exit 1
         fi
+        # Set nvmdir explicitly before installation. Default dir doesn't work for some reason.
+        export NVM_DIR="${HOME}/.nvm"
         # Remove any sneaky attempts to put __install-nvm.sh into pull-requests
         if [[ -f __install-nvm.sh ]]; then
           rm __install-nvm.sh
@@ -215,7 +217,6 @@ runs:
           echo "Error while installing nvm"
           exit 1
         fi
-        export NVM_DIR="$HOME/.nvm"
         # this loads nvm into the current terminal
         [[ -s "$NVM_DIR/nvm.sh" ]] && \. "$NVM_DIR/nvm.sh"
         ADMIN_NPM_VERSION=

--- a/install-nvm.sh
+++ b/install-nvm.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh
+wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh
 php -r '
-    $hash = "dd4b116a7452fc3bb8c0e410ceac27e19b0ba0f900fe2f91818a95c12e92130fdfb8170fec170b9fb006d316f6386f2b";
+    $hash = "faff9a72a1c8a202d6ad9b79e124684a8b128a0b3f44bdff0898bb6f4ca18550178cc7d435cfe10b2cc37396075b338d";
     if (hash_file("sha384", "install.sh") === $hash) {
         echo "Installer verified";
     } else {


### PR DESCRIPTION
Fixes:
- https://github.com/silverstripe/silverstripe-webauthn-authenticator/actions/runs/11024034775
- https://github.com/silverstripe/silverstripe-gridfieldqueuedexport/actions/runs/11042951611/job/30733961604
- https://github.com/silverstripe/silverstripe-lumberjack/actions/runs/11051906282/job/30733960799
and others

> nvm: command not found

Updated to use the latest instructions from https://github.com/nvm-sh/nvm, and added an explicit `NVM_DIR` before installing, because it wasn't able to add it to the default location (which was using `XDG_CONFIG_HOME` 'cause Ubuntu 24 is fancy or whatever)

Tested in https://github.com/creative-commoners/silverstripe-lumberjack/actions/runs/11062192583/job/30737501478 and it works well.

## Issue
- https://github.com/silverstripe/.github/issues/313