### PR TITLE
FIX Ensure nvmdir exists

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -205,6 +205,11 @@ runs:
         fi
         # Set nvmdir explicitly before installation. Default dir doesn't work for some reason.
         export NVM_DIR="${HOME}/.nvm"
+        # Installation fails if install dir is specified but doesn't exist
+        if ! [[ -d "$NVM_DIR" ]]; then
+          echo "NVM_DIR '$NVM_DIR' doesn't exist - creating it now"
+          mkdir $NVM_DIR
+        fi
         # Remove any sneaky attempts to put __install-nvm.sh into pull-requests
         if [[ -f __install-nvm.sh ]]; then
           rm __install-nvm.sh
@@ -218,7 +223,7 @@ runs:
           exit 1
         fi
         # this loads nvm into the current terminal
-        [[ -s "$NVM_DIR/nvm.sh" ]] && \. "$NVM_DIR/nvm.sh"
+        [[ -s "$NVM_DIR/nvm.sh" ]] && \. "$NVM_DIR/nvm.sh" --no-use
         ADMIN_NPM_VERSION=
         if [[ -d vendor/silverstripe/admin ]]; then
           cd vendor/silverstripe/admin


### PR DESCRIPTION
Follow-up to https://github.com/silverstripe/gha-run-tests/pull/41

Fixes https://github.com/silverstripe/silverstripe-versioned-admin/actions/runs/11042923925/job/30738441066
> You have $NVM_DIR set to "/home/runner/.nvm", but that directory does not exist. Check your profile files and environment.

Not sure why the dir existed when I tested the previous PR (looks like nvm is pre-installed for creative-commoners for some reason??). But tested this PR separately and it clearly indicates that it created the dir this time and worked as expected thereafter: https://github.com/silverstripe/silverstripe-lumberjack/actions/runs/11063333839/job/30739509770

Also need to source it with `--no-use` to avoid an `exit 3` that seems to happen if you source nvm while in a directory with a `.nvmrc` when the version of npm in that `.nvmrc` file hasn't been installed yet.

## Why did this all start breaking suddenly?

Turns out nvm was always pre-installed with ubuntu 22, but isn't with ubuntu 24. We thought we were installing it from scratch, but we were just updating it.

- [ubuntu 22 runners readme](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) shows nvm is installed already
- [ubuntu 24 runners readme](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) does not include nvm in installed software

## Issue
- https://github.com/silverstripe/.github/issues/313