### PR TITLE
FIX Don't use `--exclude-filter` for PHPUnit 9

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,12 +97,15 @@ runs:
         if [[ "${{ inputs.phpunit_fail_on_warning }}" == "true" ]]; then
           PHPUNIT_OPTIONS="$PHPUNIT_OPTIONS --fail-on-warning"
         fi
-        # Special filtering for silverstripe/framework testsuites
-        if [[ "$PHPUNIT_SUITE" == "framework-orm" ]]; then
-          PHPUNIT_OPTIONS="$PHPUNIT_OPTIONS --filter /ORM/"
-        fi
-        if [[ "$PHPUNIT_SUITE" == "framework-core" ]]; then
-          PHPUNIT_OPTIONS="$PHPUNIT_OPTIONS --exclude-filter /ORM/"
+        # --exclude-filter added in PHPUnit 11
+        if (( "$INT_VERSION" >= 110300 )); then
+          # Special filtering for silverstripe/framework testsuites
+          if [[ "$PHPUNIT_SUITE" == "framework-orm" ]]; then
+            PHPUNIT_OPTIONS="$PHPUNIT_OPTIONS --filter /ORM/"
+          fi
+          if [[ "$PHPUNIT_SUITE" == "framework-core" ]]; then
+            PHPUNIT_OPTIONS="$PHPUNIT_OPTIONS --exclude-filter /ORM/"
+          fi
         fi
         echo "PHPUNIT_OPTIONS is $PHPUNIT_OPTIONS"
         vendor/bin/phpunit $PHPUNIT_OPTIONS


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/actions/runs/11091228469/job/30814678410
> Unknown option "--exclude-filter"

## Issue
- https://github.com/silverstripe/.github/issues/313