### PR TITLE
NEW Check that all dependency licenses are permissive

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,11 @@ Run Silverstripe CI matrix tests
 Only intended to be used within [gha-ci](https://github.com/silverstripe/gha-ci). The inputs all come from the matrix generated as a part of that workflow.
 
 GitHub job permissions required: `none`
+
+## JS license checking
+
+This action will check the licences of any installed NPM dependencies against a list of allowed SPDX identifiers of open source licences. These are contained in semi-colon delimited list in `allowed-spdx-delimited.txt`. If any insalaled non-dev dependencies are found that are not in the allowed list then the job will fail. See https://spdx.org/licenses/ for a list of SPDX identifiers.
+
+Note that the `Unlicense` is an SPDX identifier for an actual license and not a placeholder for a missing license.
+
+Composer dependences are checked seperately in `ci.yml` of `silverstripe/recipe-kitchen-sink`.

--- a/action.yml
+++ b/action.yml
@@ -281,6 +281,14 @@ runs:
           echo "Running yarn lint"
           yarn run lint
         fi
+        # Validate licenses of all NPM dependencies are allowed
+        echo "Checking licenses of all dependencies"
+        # The following NPM package report as UNKNOWN or UNLICENSED, though have been manually checked they have permissive licenses:
+        EXCLUDE_PACKAGES='glob-to-regexp@0.3.0;jquery.are-you-sure@1.9.0;@silverstripe/react-injector@0.2.1;cwp-watea-theme@4.0.0;cwp-starter-theme@4.0.0'
+        npm install -g license-checker
+        SPDX_ALLOWED_DELIMITED=$(cat ${{ github.action_path }}/allowed-spdx-delimited.txt | tr -d '\n')
+        license-checker --production --unknown --out /dev/null --onlyAllow "$SPDX_ALLOWED_DELIMITED" --excludePackages "$EXCLUDE_PACKAGES"
+        # If we get to this point, everything was successful
         echo "Passed"
 
     - name: "Run PHP linting"

--- a/allowed-spdx-delimited.txt
+++ b/allowed-spdx-delimited.txt
@@ -1,0 +1,1 @@
+MIT;MIT-0;ISC;0BSD;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Python-2.0;CC0-1.0;CC-BY-3.0;CC-BY-4.0;Public Domain;Unlicense


### PR DESCRIPTION
Issue https://github.com/silverstripe/recipe-kitchen-sink/issues/80

I've simply added the checks on the the existing js + phplinting jobs respectively. This means that our CI builds won't take much longer as we don't need to spin up additional jobs to run the license checks, and both these jobs already have most the prerequisites installed i.e. node_modules and the vendor dir already exist.

The npm checker is better in that it will tell you which dependency has a non allowed license, e.g.
`Package "@babel/runtime@7.25.6" is licensed under "MIT" which is not permitted by the --onlyAllow flag. Exiting.`

I've tested the npm checker again admin, which passed, though not other modules with js deps.

The composer checker will only tell you that a non allowed license was found, though not which dependency that applies to. This is a bit annoying though it should be easy enough to manually track this down.

In terms of how it handles multi licenses composer deps like [https://github.com/nette/schema](https://github.com/nette/schema/blob/2073a5a4156aa8f2849f2e81e2b743f338ed3f45/composer.json#L6) it will look in vendor/composer/installed.json and select the first license it finds. I tested this locally by deleting the "BSD-3-Clause" entry, and then the checker showed that there was a "GPL-2.0-only" license in there. If we run into a situation in the future where this doesn't work as we want it to and it says the module is non-permissive licensed even though there's a permissive license available, we can just deal with it then. For now that I think this is fine as is and both CMS 5 + CMS 6 sink appear to pass.

For both of these we're only checking non-dev dependencies, as those are what are actually used on websites. There are some non-permissive licenses in dev-only requirements, for instance npm itself is listed with an Artistic-2.0 license, however that's obviously not part of our distribution